### PR TITLE
feat: Implement category management and persist break state

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -5,18 +5,6 @@
   "appDescription": {
     "message": "Spend too long on selected sites? A cat hijacks your screen. The cutest forced-break app."
   },
-  "usageLimitLabel": {
-    "message": "Minutes before the cat appears"
-  },
-  "breakTimeLabel": {
-    "message": "Break time (minutes)"
-  },
-  "targetSNSLabel": {
-    "message": "Target sites"
-  },
-  "catEnabledLabel": {
-    "message": "Show the cat"
-  },
   "saveButton": {
     "message": "Save"
   },
@@ -26,10 +14,43 @@
   "dismissButton": {
     "message": "Shoo, kitty!"
   },
+  "addCategoryButton": {
+    "message": "+ Add Category"
+  },
+  "removeCategoryButton": {
+    "message": "Remove category"
+  },
+  "emojiLabel": {
+    "message": "Emoji"
+  },
+  "categoryNameLabel": {
+    "message": "Name"
+  },
+  "usageLimitShortLabel": {
+    "message": "Cat appears after"
+  },
+  "breakTimeShortLabel": {
+    "message": "Break time"
+  },
+  "sitesLabel": {
+    "message": "Sites"
+  },
+  "minuteUnit": {
+    "message": "min"
+  },
   "customDomainsHint": {
     "message": "One per line, or separated by commas. URLs are OK."
   },
   "officialSiteLink": {
     "message": "Official site"
+  },
+  "quickAddLabel": {
+    "message": "$DOMAIN$ is not being tracked",
+    "placeholders": {
+      "domain": { "content": "$1", "example": "example.com" }
+    }
+  },
+  "quickAddButton": {
+    "message": "+ Add"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -5,18 +5,6 @@
   "appDescription": {
     "message": "サイトを使いすぎると猫が現れて画面をジャック。かわいい強制休憩アプリ。"
   },
-  "usageLimitLabel": {
-    "message": "何分使ったら猫を出す？"
-  },
-  "breakTimeLabel": {
-    "message": "猫が居座る時間（分）"
-  },
-  "targetSNSLabel": {
-    "message": "対象サイト"
-  },
-  "catEnabledLabel": {
-    "message": "猫を表示する"
-  },
   "saveButton": {
     "message": "保存"
   },
@@ -26,10 +14,43 @@
   "dismissButton": {
     "message": "退いてもらう"
   },
+  "addCategoryButton": {
+    "message": "+ カテゴリを追加"
+  },
+  "removeCategoryButton": {
+    "message": "カテゴリを削除"
+  },
+  "emojiLabel": {
+    "message": "絵文字"
+  },
+  "categoryNameLabel": {
+    "message": "名前"
+  },
+  "usageLimitShortLabel": {
+    "message": "猫が出るまで"
+  },
+  "breakTimeShortLabel": {
+    "message": "休憩時間"
+  },
+  "sitesLabel": {
+    "message": "サイト"
+  },
+  "minuteUnit": {
+    "message": "分"
+  },
   "customDomainsHint": {
     "message": "1行に1つ、またはカンマ区切り。URLも使えます。"
   },
   "officialSiteLink": {
     "message": "Official site"
+  },
+  "quickAddLabel": {
+    "message": "$DOMAIN$ は追跡されていません",
+    "placeholders": {
+      "domain": { "content": "$1", "example": "example.com" }
+    }
+  },
+  "quickAddButton": {
+    "message": "+ 追加"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,0 +1,56 @@
+{
+  "appName": {
+    "message": "猫咪守门神"
+  },
+  "appDescription": {
+    "message": "在某些网站上花太多时间了？看看小猫休息一下吧~"
+  },
+  "saveButton": {
+    "message": "保存"
+  },
+  "savedMessage": {
+    "message": "已保存！"
+  },
+  "dismissButton": {
+    "message": "走开，小猫！"
+  },
+  "addCategoryButton": {
+    "message": "+ 添加分类"
+  },
+  "removeCategoryButton": {
+    "message": "删除分类"
+  },
+  "emojiLabel": {
+    "message": "表情"
+  },
+  "categoryNameLabel": {
+    "message": "名称"
+  },
+  "usageLimitShortLabel": {
+    "message": "猫咪出现于"
+  },
+  "breakTimeShortLabel": {
+    "message": "休息时长"
+  },
+  "sitesLabel": {
+    "message": "网站"
+  },
+  "minuteUnit": {
+    "message": "分钟"
+  },
+  "customDomainsHint": {
+    "message": "每行一个，或用逗号分隔。支持输入完整 URL。"
+  },
+  "officialSiteLink": {
+    "message": "官方网站"
+  },
+  "quickAddLabel": {
+    "message": "未追踪 $DOMAIN$",
+    "placeholders": {
+      "domain": { "content": "$1", "example": "example.com" }
+    }
+  },
+  "quickAddButton": {
+    "message": "+ 添加"
+  }
+}

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1,0 +1,56 @@
+{
+  "appName": {
+    "message": "貓咪守門神"
+  },
+  "appDescription": {
+    "message": "在某些網站上花太多時間了？看看小貓休息一下吧~"
+  },
+  "saveButton": {
+    "message": "儲存"
+  },
+  "savedMessage": {
+    "message": "已儲存！"
+  },
+  "dismissButton": {
+    "message": "走開，小貓！"
+  },
+  "addCategoryButton": {
+    "message": "+ 新增分類"
+  },
+  "removeCategoryButton": {
+    "message": "刪除分類"
+  },
+  "emojiLabel": {
+    "message": "表情"
+  },
+  "categoryNameLabel": {
+    "message": "名稱"
+  },
+  "usageLimitShortLabel": {
+    "message": "貓咪出現於"
+  },
+  "breakTimeShortLabel": {
+    "message": "休息時長"
+  },
+  "sitesLabel": {
+    "message": "網站"
+  },
+  "minuteUnit": {
+    "message": "分鐘"
+  },
+  "customDomainsHint": {
+    "message": "每行一個，或用逗號分隔。支援輸入完整 URL。"
+  },
+  "officialSiteLink": {
+    "message": "官方網站"
+  },
+  "quickAddLabel": {
+    "message": "未追蹤 $DOMAIN$",
+    "placeholders": {
+      "domain": { "content": "$1", "example": "example.com" }
+    }
+  },
+  "quickAddButton": {
+    "message": "+ 新增"
+  }
+}

--- a/content.js
+++ b/content.js
@@ -13,6 +13,7 @@ const preventScroll = (e) => e.preventDefault();
 
 const hostname = location.hostname;
 const USAGE_STORAGE_KEY = 'catGatekeeperUsage';
+const BREAK_STORAGE_KEY = 'catGatekeeperBreak';
 const USAGE_STALE_AFTER_MS = 30 * 60 * 1000;
 const USAGE_SAVE_INTERVAL_SECONDS = 5;
 
@@ -71,6 +72,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     catIsActive = false;
     stopCountdown();
     resetUsageSeconds(dismissedUsageKey);
+    clearBreakUntil(dismissedUsageKey);
     overlay.style.transition = 'opacity 0.5s';
     overlay.style.opacity = '0';
     setTimeout(() => {
@@ -98,30 +100,12 @@ function getUsageStorageKey(usageKey) {
   return `${USAGE_STORAGE_KEY}:${usageKey}`;
 }
 
-function loadUsageSeconds(usageKey, callback) {
-  const storageKey = getUsageStorageKey(usageKey);
-
-  chrome.storage.local.get({ [storageKey]: null }, (result) => {
-    const entry = result[storageKey];
-    const now = Date.now();
-
-    if (!entry || typeof entry !== 'object') {
-      callback(0);
-      return;
-    }
-
-    if (now - Number(entry.updatedAt || 0) > USAGE_STALE_AFTER_MS) {
-      callback(0);
-      return;
-    }
-
-    callback(Math.max(0, Number.parseInt(entry.seconds, 10) || 0));
-  });
+function getBreakStorageKey(usageKey) {
+  return `${BREAK_STORAGE_KEY}:${usageKey}`;
 }
 
 function saveUsageSeconds(usageKey, seconds) {
   if (!usageKey) return;
-
   chrome.storage.local.set({
     [getUsageStorageKey(usageKey)]: {
       seconds: Math.max(0, seconds),
@@ -132,6 +116,16 @@ function saveUsageSeconds(usageKey, seconds) {
 
 function resetUsageSeconds(usageKey) {
   saveUsageSeconds(usageKey, 0);
+}
+
+function saveBreakUntil(usageKey, breakUntil) {
+  if (!usageKey) return;
+  chrome.storage.local.set({ [getBreakStorageKey(usageKey)]: breakUntil });
+}
+
+function clearBreakUntil(usageKey) {
+  if (!usageKey) return;
+  chrome.storage.local.remove(getBreakStorageKey(usageKey));
 }
 
 document.addEventListener('visibilitychange', () => {
@@ -150,16 +144,38 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
 
   if (resetUsage) {
     resetUsageSeconds(usageKey);
+    clearBreakUntil(usageKey);
   }
 
-  loadUsageSeconds(usageKey, (initialSeconds) => {
-    if (
-      runId !== trackerRunId ||
-      usageKey !== currentUsageKey ||
-      catIsActive ||
-      !currentCategory
-    ) {
+  const usageStorageKey = getUsageStorageKey(usageKey);
+  const breakStorageKey = getBreakStorageKey(usageKey);
+
+  chrome.storage.local.get({ [usageStorageKey]: null, [breakStorageKey]: 0 }, (result) => {
+    if (runId !== trackerRunId || usageKey !== currentUsageKey || catIsActive || !currentCategory) {
       return;
+    }
+
+    // If a break is still active (e.g. tab was duplicated during a break), resume it
+    const breakUntil = Number(result[breakStorageKey]) || 0;
+    const remainingMs = breakUntil - Date.now();
+    if (remainingMs > 0) {
+      catIsActive = true;
+      showCat(Math.ceil(remainingMs / 1000), usageKey, () => {
+        if (currentCategory && usageKey === currentUsageKey) {
+          startTracking(currentCategory.usageLimit, currentCategory.breakTime);
+        }
+      });
+      return;
+    }
+
+    if (breakUntil > 0) clearBreakUntil(usageKey); // stale entry, clean up
+
+    // Normal usage tracking
+    const entry = result[usageStorageKey];
+    const now = Date.now();
+    let initialSeconds = 0;
+    if (entry && typeof entry === 'object' && now - Number(entry.updatedAt || 0) <= USAGE_STALE_AFTER_MS) {
+      initialSeconds = Math.max(0, Number.parseInt(entry.seconds, 10) || 0);
     }
 
     trackerRunning = true;
@@ -174,7 +190,6 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
         resetUsageSeconds(usageKey);
         return;
       }
-
       saveUsageSeconds(usageKey, localSeconds);
     };
 
@@ -202,7 +217,8 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
         shouldPersistUsage = false;
         localSeconds = 0;
         resetUsageSeconds(usageKey);
-        showCat(breakTime, usageLimit, () => {
+        saveBreakUntil(usageKey, Date.now() + breakTime * 60 * 1000);
+        showCat(breakTime * 60, usageKey, () => {
           if (currentCategory && usageKey === currentUsageKey) {
             startTracking(currentCategory.usageLimit, currentCategory.breakTime);
           }
@@ -236,7 +252,7 @@ chrome.storage.local.get(
   (settings) => applySettings(settings)
 );
 
-function showCat(breakMinutes, usageLimit, onBreakEnd) {
+function showCat(breakSeconds, usageKey, onBreakEnd) {
   document.getElementById('cat-gatekeeper-overlay')?.remove();
 
   const overlay = document.createElement('div');
@@ -247,7 +263,7 @@ function showCat(breakMinutes, usageLimit, onBreakEnd) {
   // カウントダウン
   const countdown = document.createElement('div');
   countdown.id = 'cat-gatekeeper-countdown';
-  let seconds = breakMinutes * 60;
+  let seconds = breakSeconds;
 
   let countdownCancelled = false;
   stopCountdown = () => { countdownCancelled = true; };
@@ -262,6 +278,7 @@ function showCat(breakMinutes, usageLimit, onBreakEnd) {
       setTimeout(updateCountdown, 1000);
     } else {
       catIsActive = false;
+      clearBreakUntil(usageKey);
       overlay.style.transition = 'opacity 1s';
       overlay.style.opacity = '0';
       setTimeout(() => {

--- a/content.js
+++ b/content.js
@@ -16,35 +16,27 @@ const USAGE_STORAGE_KEY = 'catGatekeeperUsage';
 const USAGE_STALE_AFTER_MS = 30 * 60 * 1000;
 const USAGE_SAVE_INTERVAL_SECONDS = 5;
 
-function mergeSettingsWithDefaults(settings) {
-  return shared.normalizeSettings(settings);
-}
-
-function getMatchedDomain(settings) {
-  return shared.normalizeDomainList(settings.customDomains).find((domain) =>
-    shared.hostnameMatchesDomain(hostname, domain)
-  ) || '';
-}
-
-function isSiteEnabled(settings) {
-  return !!getMatchedDomain(settings);
-}
-
 function applySettings(settings, { resetUsage = false } = {}) {
-  const mergedSettings = mergeSettingsWithDefaults(settings);
-  currentUsageLimit = mergedSettings.usageLimit;
-  currentBreakTime = mergedSettings.breakTime;
-  currentCustomDomains = mergedSettings.customDomains;
-  currentUsageKey = getMatchedDomain(mergedSettings);
-  currentSnsEnabled = mergedSettings.catEnabled && !!currentUsageKey;
+  const merged = shared.normalizeSettings(settings);
+  currentCategories = merged.categories;
 
-  if (!currentSnsEnabled) {
+  const newCategory = shared.getCategoryForHostname(hostname, currentCategories);
+
+  if (!newCategory) {
+    currentCategory = null;
+    currentUsageKey = '';
     stopTracker();
     return;
   }
 
+  const matchedDomain = newCategory.domains.find((d) => shared.hostnameMatchesDomain(hostname, d));
+  const newUsageKey = shared.normalizeDomainEntry(matchedDomain || hostname);
+
+  currentCategory = newCategory;
+  currentUsageKey = newUsageKey;
+
   if (!catIsActive) {
-    startTracking(currentUsageLimit, currentBreakTime, { resetUsage });
+    startTracking(newCategory.usageLimit, newCategory.breakTime, { resetUsage });
   }
 }
 
@@ -58,9 +50,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       catIsActive,
       hostname,
       trackerRunning,
-      customDomains: currentCustomDomains,
-      isTracked: currentSnsEnabled,
+      isTracked: !!currentCategory,
       trackedDomain: currentUsageKey,
+      currentCategory,
       hasFocus: document.hasFocus(),
       isHidden: document.hidden,
     });
@@ -86,8 +78,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       document.documentElement.style.overflow = '';
       document.removeEventListener('wheel', preventScroll);
       document.removeEventListener('touchmove', preventScroll);
-      if (currentSnsEnabled && dismissedUsageKey === currentUsageKey) {
-        startTracking(currentUsageLimit, currentBreakTime);
+      if (currentCategory && dismissedUsageKey === currentUsageKey) {
+        startTracking(currentCategory.usageLimit, currentCategory.breakTime);
       }
     }, 500);
   }
@@ -96,10 +88,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 let resetSeconds = () => {};
 let stopTracker = () => {};
 let stopCountdown = () => {};
-let currentUsageLimit = 60;
-let currentBreakTime = 5;
-let currentSnsEnabled = false;
-let currentCustomDomains = [];
+let currentCategories = [];
+let currentCategory = null;
 let currentUsageKey = '';
 let catAssetsPrepared = false;
 let trackerRunId = 0;
@@ -156,8 +146,6 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
   prepareCatAssets();
   stopTracker();
   const runId = ++trackerRunId;
-  currentUsageLimit = usageLimit;
-  currentBreakTime = breakTime;
   const usageKey = currentUsageKey;
 
   if (resetUsage) {
@@ -169,7 +157,7 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
       runId !== trackerRunId ||
       usageKey !== currentUsageKey ||
       catIsActive ||
-      !currentSnsEnabled
+      !currentCategory
     ) {
       return;
     }
@@ -191,7 +179,7 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
     };
 
     const tracker = setInterval(() => {
-      if (usageKey !== currentUsageKey || catIsActive || !currentSnsEnabled) {
+      if (usageKey !== currentUsageKey || catIsActive || !currentCategory) {
         clearInterval(tracker);
         trackerRunning = false;
         return;
@@ -215,8 +203,8 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
         localSeconds = 0;
         resetUsageSeconds(usageKey);
         showCat(breakTime, usageLimit, () => {
-          if (currentSnsEnabled && usageKey === currentUsageKey) {
-            startTracking(currentUsageLimit, currentBreakTime);
+          if (currentCategory && usageKey === currentUsageKey) {
+            startTracking(currentCategory.usageLimit, currentCategory.breakTime);
           }
         });
       }
@@ -243,9 +231,10 @@ function prepareCatAssets() {
   catAssetsPrepared = true;
 }
 
-chrome.storage.local.get(null, (settings) => {
-  applySettings(settings);
-});
+chrome.storage.local.get(
+  { categories: null, customDomains: null, usageLimit: shared.LEGACY_DEFAULTS.usageLimit, breakTime: shared.LEGACY_DEFAULTS.breakTime },
+  (settings) => applySettings(settings)
+);
 
 function showCat(breakMinutes, usageLimit, onBreakEnd) {
   document.getElementById('cat-gatekeeper-overlay')?.remove();

--- a/popup.html
+++ b/popup.html
@@ -9,7 +9,7 @@
     }
 
     *::-webkit-scrollbar {
-      width: 10px;
+      width: 6px;
     }
 
     *::-webkit-scrollbar-track {
@@ -19,7 +19,6 @@
 
     *::-webkit-scrollbar-thumb {
       background: #ff6b35;
-      border: 2px solid #2e2e2e;
       border-radius: 8px;
     }
 
@@ -33,52 +32,309 @@
       padding: 14px;
       background: #1a1a1a;
       color: #fff;
+      margin: 0;
     }
 
     h1 {
       font-size: 16px;
-      margin: 0 0 16px;
-      text-align: center;
+      margin: 0 0 14px;
       color: #fff;
     }
 
-    .section {
-      margin-bottom: 14px;
+    /* Category cards */
+    #categoriesContainer {
+      margin-bottom: 8px;
     }
 
-    .section label {
-      display: block;
-      font-size: 12px;
-      color: #aaa;
+    .category-card {
       margin-bottom: 6px;
+      border-radius: 8px;
+      overflow: hidden;
+      background: #252525;
     }
 
-    .section input[type="number"] {
-      width: 100%;
-      padding: 8px;
-      border-radius: 8px;
-      border: none;
-      background: #2e2e2e;
-      color: #fff;
-      font-size: 14px;
-      box-sizing: border-box;
+    .category-header {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      padding: 10px 10px;
+      cursor: pointer;
+      user-select: none;
     }
 
-    .section textarea {
-      width: 100%;
-      min-height: 76px;
-      padding: 8px;
-      border-radius: 8px;
-      border: none;
+    .category-header:hover {
       background: #2e2e2e;
+    }
+
+    .toggle-arrow {
+      font-size: 9px;
+      color: #666;
+      width: 9px;
+      flex-shrink: 0;
+    }
+
+    .header-emoji {
+      font-size: 15px;
+      line-height: 1;
+      flex-shrink: 0;
+    }
+
+    .header-name {
+      flex: 1;
+      font-size: 13px;
+      font-weight: 600;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .header-summary {
+      font-size: 11px;
+      color: #666;
+      flex-shrink: 0;
+    }
+
+    .category-body {
+      padding: 0 10px 10px;
+      border-top: 1px solid #333;
+    }
+
+    .category-body[hidden] {
+      display: none;
+    }
+
+    /* Meta row: emoji + name */
+    .cat-meta-row {
+      display: flex;
+      gap: 8px;
+      padding-top: 10px;
+      margin-bottom: 8px;
+    }
+
+    .cat-meta-row .field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .cat-meta-row .field-emoji {
+      flex-shrink: 0;
+    }
+
+    .cat-meta-row .field-name {
+      flex: 1;
+      min-width: 0;
+    }
+
+    /* Time row: usage limit + break time */
+    .cat-time-row {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+
+    .cat-time-field {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .input-unit {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .input-unit .unit {
+      font-size: 11px;
+      color: #666;
+      flex-shrink: 0;
+    }
+
+    /* Shared input styles */
+    .field-label {
+      font-size: 10px;
+      color: #777;
+    }
+
+    input[type="text"],
+    input[type="number"] {
+      padding: 6px 7px;
+      border-radius: 6px;
+      border: none;
+      background: #1a1a1a;
       color: #fff;
       font-size: 13px;
-      line-height: 1.45;
-      resize: vertical;
       box-sizing: border-box;
     }
 
-    button {
+    input[type="text"]:focus,
+    input[type="number"]:focus {
+      outline: 1px solid #ff6b35;
+    }
+
+    .emoji-input {
+      width: 44px;
+      text-align: center;
+      font-size: 15px;
+      padding: 4px 6px;
+    }
+
+    .name-input {
+      width: 100%;
+    }
+
+    .usage-limit-input,
+    .break-time-input {
+      width: 100%;
+      min-width: 0;
+    }
+
+    /* Sites textarea */
+    .domains-label {
+      display: block;
+      font-size: 10px;
+      color: #777;
+      margin-bottom: 4px;
+    }
+
+    .domains-textarea {
+      width: 100%;
+      min-height: 60px;
+      padding: 6px 7px;
+      border-radius: 6px;
+      border: none;
+      background: #1a1a1a;
+      color: #fff;
+      font-size: 12px;
+      line-height: 1.6;
+      resize: vertical;
+      box-sizing: border-box;
+      font-family: monospace;
+    }
+
+    .domains-textarea:focus {
+      outline: 1px solid #ff6b35;
+    }
+
+    .hint {
+      margin: 4px 0 8px;
+      font-size: 10px;
+      color: #555;
+      line-height: 1.4;
+    }
+
+    /* Quick-add banner */
+    #quickAddBanner {
+      background: #1b261b;
+      border: 1px solid #2d422d;
+      border-radius: 8px;
+      padding: 9px 10px;
+      margin-bottom: 10px;
+    }
+
+    #quickAddLabel {
+      font-size: 11px;
+      color: #7aaa7a;
+      margin: 0 0 7px;
+    }
+
+    #quickAddLabel strong {
+      color: #9dcc9d;
+    }
+
+    .quick-add-row {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
+
+    #quickAddSelect {
+      flex: 1;
+      min-width: 0;
+      padding: 6px 7px;
+      border-radius: 6px;
+      border: none;
+      background: #111;
+      color: #fff;
+      font-size: 13px;
+      cursor: pointer;
+    }
+
+    #quickAddBtn {
+      padding: 6px 11px;
+      border-radius: 6px;
+      border: none;
+      background: #3a6b3a;
+      color: #fff;
+      font-size: 12px;
+      font-weight: bold;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
+    #quickAddBtn:hover {
+      background: #4a864a;
+    }
+
+    .remove-btn {
+      width: 100%;
+      padding: 6px;
+      border-radius: 6px;
+      border: 1px solid #383838;
+      background: transparent;
+      color: #666;
+      font-size: 11px;
+      cursor: pointer;
+      transition: color 0.15s, border-color 0.15s, background 0.15s;
+    }
+
+    .remove-btn:hover {
+      background: #2a1010;
+      color: #e05555;
+      border-color: #e05555;
+    }
+
+    /* Add category button */
+    #addCategoryBtn {
+      width: 100%;
+      padding: 8px;
+      border-radius: 8px;
+      border: 1px dashed #3a3a3a;
+      background: transparent;
+      color: #666;
+      font-size: 12px;
+      cursor: pointer;
+      margin-bottom: 10px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+
+    #addCategoryBtn:hover {
+      border-color: #ff6b35;
+      color: #ff6b35;
+    }
+
+    /* Action buttons */
+    #dismissBtn {
+      width: 100%;
+      padding: 10px;
+      border-radius: 8px;
+      border: none;
+      background: #3a3a3a;
+      color: #ccc;
+      font-size: 14px;
+      font-weight: bold;
+      cursor: pointer;
+      margin-bottom: 8px;
+      display: none;
+    }
+
+    #dismissBtn:hover {
+      background: #484848;
+    }
+
+    #saveBtn {
       width: 100%;
       padding: 10px;
       border-radius: 8px;
@@ -90,18 +346,8 @@
       cursor: pointer;
     }
 
-    button:hover {
+    #saveBtn:hover {
       background: #e55a25;
-    }
-
-    #dismissBtn {
-      background: #444;
-      margin-bottom: 12px;
-      display: none;
-    }
-
-    #dismissBtn:hover {
-      background: #555;
     }
 
     .saved {
@@ -110,30 +356,6 @@
       color: #aaa;
       margin-top: 8px;
       display: none;
-    }
-
-    .hint {
-      margin: 6px 0 0;
-      font-size: 11px;
-      line-height: 1.4;
-      color: #888;
-    }
-
-    .toggle-row {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      font-size: 13px;
-      line-height: 1.4;
-      color: #ddd;
-      cursor: pointer;
-    }
-
-    .toggle-row input {
-      width: 16px;
-      height: 16px;
-      margin: 0;
-      accent-color: #ff6b35;
     }
 
     .footer-link {
@@ -156,31 +378,19 @@
   </style>
 </head>
 <body>
-  <h1>Cat Gatekeeper</h1>
+  <h1><span aria-hidden="true">🐈️</span> Cat Gatekeeper</h1>
 
-  <div class="section">
-    <label data-i18n="usageLimitLabel"></label>
-    <input type="number" id="usageLimit" min="1" max="480" value="30">
+  <div id="quickAddBanner" hidden>
+    <p id="quickAddLabel"></p>
+    <div class="quick-add-row">
+      <select id="quickAddSelect"></select>
+      <button id="quickAddBtn"></button>
+    </div>
   </div>
 
-  <div class="section">
-    <label data-i18n="breakTimeLabel"></label>
-    <input type="number" id="breakTime" min="1" max="60" value="5">
-  </div>
+  <div id="categoriesContainer"></div>
 
-  <div class="section">
-    <label class="toggle-row">
-      <input type="checkbox" id="catEnabled">
-      <span data-i18n="catEnabledLabel"></span>
-    </label>
-  </div>
-
-  <div class="section">
-    <label for="customDomains" data-i18n="targetSNSLabel"></label>
-    <textarea id="customDomains" spellcheck="false" placeholder="x.com&#10;youtube.com&#10;example.com"></textarea>
-    <p class="hint" data-i18n="customDomainsHint"></p>
-  </div>
-
+  <button id="addCategoryBtn"></button>
   <button id="dismissBtn" data-i18n="dismissButton"></button>
   <button id="saveBtn" data-i18n="saveButton"></button>
   <div class="saved" id="savedMsg" data-i18n="savedMessage"></div>

--- a/popup.js
+++ b/popup.js
@@ -1,33 +1,45 @@
-// 翻訳を適用
-document.querySelectorAll('[data-i18n]').forEach(el => {
+document.querySelectorAll('[data-i18n]').forEach((el) => {
   el.textContent = chrome.i18n.getMessage(el.dataset.i18n);
 });
 
 const shared = globalThis.CatGatekeeperShared;
 
-function mergeSettingsWithDefaults(settings) {
-  return shared.normalizeSettings(settings);
-}
+const i18n = {
+  emoji:           () => chrome.i18n.getMessage('emojiLabel'),
+  name:            () => chrome.i18n.getMessage('categoryNameLabel'),
+  limit:           () => chrome.i18n.getMessage('usageLimitShortLabel'),
+  breakTime:       () => chrome.i18n.getMessage('breakTimeShortLabel'),
+  sites:           () => chrome.i18n.getMessage('sitesLabel'),
+  hint:            () => chrome.i18n.getMessage('customDomainsHint'),
+  remove:          () => chrome.i18n.getMessage('removeCategoryButton'),
+  addCat:          () => chrome.i18n.getMessage('addCategoryButton'),
+  min:             () => chrome.i18n.getMessage('minuteUnit'),
+  quickAddBtn:     () => chrome.i18n.getMessage('quickAddButton'),
+  quickAddLabel:   (host) => chrome.i18n.getMessage('quickAddLabel', [host]),
+};
 
-function getClampedNumberValue(inputId, fallbackValue) {
-  const input = document.getElementById(inputId);
-  const parsedValue = Number.parseInt(input.value, 10);
-  const minValue = Number.parseInt(input.min, 10);
-  const maxValue = Number.parseInt(input.max, 10);
+document.getElementById('addCategoryBtn').textContent = i18n.addCat();
+document.getElementById('quickAddBtn').textContent = i18n.quickAddBtn();
 
-  if (Number.isNaN(parsedValue)) {
-    return fallbackValue;
+// Coordinate two async loads before showing quick-add
+let _loadedCategories = null;
+let _tabStatus = null;
+
+function _tryShowQuickAdd() {
+  if (!_loadedCategories || !_tabStatus) return;
+  if (!_tabStatus.isTracked && _tabStatus.hostname) {
+    showQuickAdd(_tabStatus.hostname, _loadedCategories);
   }
-
-  return Math.min(Math.max(parsedValue, minValue), maxValue);
 }
 
-// 猫が出てるときだけ閉じるボタンを表示
+// Show dismiss button when cat is active; capture tab status for quick-add
 const dismissBtn = document.getElementById('dismissBtn');
 chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
   chrome.tabs.sendMessage(tabs[0].id, { type: 'GET_CAT_STATUS' }, (res) => {
     void chrome.runtime.lastError;
     if (res?.catIsActive) dismissBtn.style.display = 'block';
+    _tabStatus = res || { isTracked: true }; // treat error as tracked (no banner)
+    _tryShowQuickAdd();
   });
 });
 
@@ -40,42 +52,298 @@ dismissBtn.addEventListener('click', () => {
   });
 });
 
-const defaults = {
-  ...shared.DEFAULT_SETTINGS,
-};
+// Load settings and render
+chrome.storage.local.get(
+  { categories: null, customDomains: null, usageLimit: shared.LEGACY_DEFAULTS.usageLimit, breakTime: shared.LEGACY_DEFAULTS.breakTime },
+  (raw) => {
+    const { categories } = shared.normalizeSettings(raw);
+    _loadedCategories = categories;
+    renderCategories(categories);
+    _tryShowQuickAdd();
+  }
+);
 
-// 設定を読み込む
-chrome.storage.local.get(null, (settings) => {
-  const mergedSettings = mergeSettingsWithDefaults(settings);
+function showQuickAdd(hostname, categories) {
+  const banner = document.getElementById('quickAddBanner');
+  const label = document.getElementById('quickAddLabel');
+  const select = document.getElementById('quickAddSelect');
+  const btn = document.getElementById('quickAddBtn');
 
-  document.getElementById('usageLimit').value = mergedSettings.usageLimit;
-  document.getElementById('breakTime').value = mergedSettings.breakTime;
-  document.getElementById('customDomains').value = mergedSettings.customDomains.join('\n');
-  document.getElementById('catEnabled').checked = mergedSettings.catEnabled;
-});
+  // Build label with bold hostname
+  label.textContent = '';
+  const msg = i18n.quickAddLabel(hostname);
+  const parts = msg.split(hostname);
+  if (parts.length === 2) {
+    label.append(parts[0]);
+    const strong = document.createElement('strong');
+    strong.textContent = hostname;
+    label.appendChild(strong);
+    label.append(parts[1]);
+  } else {
+    label.textContent = msg;
+  }
 
-// 設定を保存する
-document.getElementById('saveBtn').addEventListener('click', () => {
-  const settings = {
-    catEnabled: document.getElementById('catEnabled').checked,
-    usageLimit: getClampedNumberValue('usageLimit', defaults.usageLimit),
-    breakTime: getClampedNumberValue('breakTime', defaults.breakTime),
-    customDomains: shared.normalizeDomainList(document.getElementById('customDomains').value),
+  // Populate category selector
+  select.innerHTML = '';
+  categories.forEach((cat) => {
+    const opt = document.createElement('option');
+    opt.value = cat.id;
+    opt.textContent = `${cat.emoji} ${cat.name}`;
+    select.appendChild(opt);
+  });
+
+  banner.hidden = false;
+
+  btn.addEventListener('click', () => {
+    const selectedId = select.value;
+    const card = document.querySelector(`.category-card[data-id="${CSS.escape(selectedId)}"]`);
+    if (!card) return;
+
+    // Append domain to the target category's textarea
+    const textarea = card._inputs.domains;
+    const current = textarea.value.trim();
+    textarea.value = current ? `${current}\n${hostname}` : hostname;
+
+    // Expand the card so the user can see the change
+    const body = card.querySelector('.category-body');
+    if (body.hidden) {
+      body.hidden = false;
+      card.querySelector('.toggle-arrow').textContent = '▼';
+      card.querySelector('.category-header').setAttribute('aria-expanded', 'true');
+    }
+
+    banner.hidden = true;
+    document.getElementById('saveBtn').click();
+    card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  });
+}
+
+function renderCategories(categories) {
+  const container = document.getElementById('categoriesContainer');
+  container.innerHTML = '';
+  categories.forEach((cat) => container.appendChild(buildCategoryCard(cat, false)));
+}
+
+function buildCategoryCard(cat, expanded) {
+  const card = document.createElement('div');
+  card.className = 'category-card';
+  card.dataset.id = cat.id;
+
+  // ── Header ──────────────────────────────────────────────
+  const header = document.createElement('div');
+  header.className = 'category-header';
+  header.setAttribute('role', 'button');
+  header.setAttribute('aria-expanded', String(expanded));
+
+  const arrow = document.createElement('span');
+  arrow.className = 'toggle-arrow';
+  arrow.textContent = expanded ? '▼' : '▶';
+
+  const headerEmoji = document.createElement('span');
+  headerEmoji.className = 'header-emoji';
+  headerEmoji.textContent = cat.emoji;
+
+  const headerName = document.createElement('span');
+  headerName.className = 'header-name';
+  headerName.textContent = cat.name;
+
+  const headerSummary = document.createElement('span');
+  headerSummary.className = 'header-summary';
+  headerSummary.textContent = `${cat.usageLimit} ${i18n.min()}`;
+
+  header.append(arrow, headerEmoji, headerName, headerSummary);
+
+  // ── Body ────────────────────────────────────────────────
+  const body = document.createElement('div');
+  body.className = 'category-body';
+  body.hidden = !expanded;
+
+  // Emoji + Name row
+  const metaRow = document.createElement('div');
+  metaRow.className = 'cat-meta-row';
+
+  const emojiField = document.createElement('div');
+  emojiField.className = 'field field-emoji';
+  const emojiLabel = document.createElement('span');
+  emojiLabel.className = 'field-label';
+  emojiLabel.textContent = i18n.emoji();
+  const emojiInput = document.createElement('input');
+  emojiInput.type = 'text';
+  emojiInput.className = 'emoji-input';
+  emojiInput.value = cat.emoji;
+  emojiInput.maxLength = 4;
+  emojiInput.addEventListener('input', () => {
+    headerEmoji.textContent = emojiInput.value || '📌';
+  });
+  emojiField.append(emojiLabel, emojiInput);
+
+  const nameField = document.createElement('div');
+  nameField.className = 'field field-name';
+  const nameLabel = document.createElement('span');
+  nameLabel.className = 'field-label';
+  nameLabel.textContent = i18n.name();
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'name-input';
+  nameInput.value = cat.name;
+  nameInput.maxLength = 50;
+  nameInput.placeholder = 'Category';
+  nameInput.addEventListener('input', () => {
+    headerName.textContent = nameInput.value || 'Category';
+  });
+  nameField.append(nameLabel, nameInput);
+
+  metaRow.append(emojiField, nameField);
+
+  // Usage limit + Break time row
+  const timeRow = document.createElement('div');
+  timeRow.className = 'cat-time-row';
+
+  const usageLimitField = buildNumberField(i18n.limit(), cat.usageLimit, 1, 480, 'usage-limit-input');
+  usageLimitField.input.addEventListener('input', () => {
+    const val = Number.parseInt(usageLimitField.input.value, 10);
+    if (!Number.isNaN(val) && val >= 1 && val <= 480) {
+      headerSummary.textContent = `${val} ${i18n.min()}`;
+    }
+  });
+
+  const breakTimeField = buildNumberField(i18n.breakTime(), cat.breakTime, 1, 60, 'break-time-input');
+
+  timeRow.append(usageLimitField.el, breakTimeField.el);
+
+  // Sites textarea
+  const sitesLabel = document.createElement('label');
+  sitesLabel.className = 'domains-label';
+  sitesLabel.textContent = i18n.sites();
+
+  const textarea = document.createElement('textarea');
+  textarea.className = 'domains-textarea';
+  textarea.spellcheck = false;
+  textarea.placeholder = 'youtube.com\nexample.com';
+  textarea.value = cat.domains.join('\n');
+
+  const hint = document.createElement('p');
+  hint.className = 'hint';
+  hint.textContent = i18n.hint();
+
+  // Remove button
+  const removeBtn = document.createElement('button');
+  removeBtn.className = 'remove-btn';
+  removeBtn.textContent = i18n.remove();
+  removeBtn.addEventListener('click', () => card.remove());
+
+  body.append(metaRow, timeRow, sitesLabel, textarea, hint, removeBtn);
+
+  // Toggle expand/collapse
+  header.addEventListener('click', () => {
+    const willExpand = body.hidden;
+    body.hidden = !willExpand;
+    arrow.textContent = willExpand ? '▼' : '▶';
+    header.setAttribute('aria-expanded', String(willExpand));
+  });
+
+  card.append(header, body);
+
+  // Attach references for reading on save
+  card._inputs = {
+    emoji: emojiInput,
+    name: nameInput,
+    usageLimit: usageLimitField.input,
+    breakTime: breakTimeField.input,
+    domains: textarea,
   };
 
-  document.getElementById('usageLimit').value = settings.usageLimit;
-  document.getElementById('breakTime').value = settings.breakTime;
-  document.getElementById('customDomains').value = settings.customDomains.join('\n');
+  return card;
+}
 
-  chrome.storage.local.set(settings, () => {
+function buildNumberField(labelText, value, min, max, className) {
+  const el = document.createElement('div');
+  el.className = 'cat-time-field';
+
+  const label = document.createElement('span');
+  label.className = 'field-label';
+  label.textContent = labelText;
+
+  const inputUnit = document.createElement('div');
+  inputUnit.className = 'input-unit';
+
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.className = className;
+  input.min = min;
+  input.max = max;
+  input.value = value;
+
+  const unit = document.createElement('span');
+  unit.className = 'unit';
+  unit.textContent = i18n.min();
+
+  inputUnit.append(input, unit);
+  el.append(label, inputUnit);
+
+  return { el, input };
+}
+
+function readCardCategories() {
+  return Array.from(document.querySelectorAll('.category-card')).map((card, i) => {
+    const inp = card._inputs;
+    return shared.normalizeCategory({
+      id: card.dataset.id || `cat_${Date.now()}_${i}`,
+      emoji: inp.emoji.value,
+      name: inp.name.value,
+      usageLimit: Number.parseInt(inp.usageLimit.value, 10),
+      breakTime: Number.parseInt(inp.breakTime.value, 10),
+      domains: inp.domains.value,
+    });
+  }).filter(Boolean);
+}
+
+// Add category
+document.getElementById('addCategoryBtn').addEventListener('click', () => {
+  const cat = shared.normalizeCategory({
+    id: `cat_${Date.now()}`,
+    name: '',
+    emoji: '📌',
+    usageLimit: 30,
+    breakTime: 5,
+    domains: [],
+  });
+  const card = buildCategoryCard(cat, true);
+  document.getElementById('categoriesContainer').appendChild(card);
+  card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  card._inputs.name.focus();
+});
+
+// Save
+document.getElementById('saveBtn').addEventListener('click', () => {
+  const categories = readCardCategories();
+
+  // Reflect normalized values back into inputs
+  document.querySelectorAll('.category-card').forEach((card, i) => {
+    const cat = categories[i];
+    if (!cat) return;
+    const inp = card._inputs;
+    inp.emoji.value = cat.emoji;
+    inp.name.value = cat.name;
+    inp.usageLimit.value = cat.usageLimit;
+    inp.breakTime.value = cat.breakTime;
+    inp.domains.value = cat.domains.join('\n');
+    card.querySelector('.header-emoji').textContent = cat.emoji;
+    card.querySelector('.header-name').textContent = cat.name;
+    card.querySelector('.header-summary').textContent = `${cat.usageLimit} ${i18n.min()}`;
+  });
+
+  chrome.storage.local.set({ categories }, () => {
     const msg = document.getElementById('savedMsg');
     msg.style.display = 'block';
-    setTimeout(() => msg.style.display = 'none', 2000);
+    setTimeout(() => { msg.style.display = 'none'; }, 2000);
 
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      chrome.tabs.sendMessage(tabs[0].id, { type: 'UPDATE_SETTINGS', settings }, () => {
-        void chrome.runtime.lastError;
-      });
+      chrome.tabs.sendMessage(
+        tabs[0].id,
+        { type: 'UPDATE_SETTINGS', settings: { categories } },
+        () => { void chrome.runtime.lastError; }
+      );
     });
   });
 });

--- a/shared.js
+++ b/shared.js
@@ -7,30 +7,66 @@
 
   root.CatGatekeeperShared = shared;
 })(typeof globalThis !== 'undefined' ? globalThis : this, () => {
-  const DEFAULT_DOMAINS = Object.freeze([
-    'x.com',
-    'twitter.com',
-    'youtube.com',
-    'facebook.com',
-    'reddit.com',
-    'threads.net',
-    'bsky.app',
+  const DEFAULT_CATEGORIES = Object.freeze([
+    Object.freeze({
+      id: 'social',
+      name: 'Social',
+      emoji: '💬',
+      usageLimit: 30,
+      breakTime: 5,
+      domains: Object.freeze([
+        'x.com',
+        'facebook.com',
+        'threads.net',
+        'instagram.com',
+        'bsky.app',
+        'xiaohongshu.com',
+        'reddit.com',
+      ]),
+    }),
+    Object.freeze({
+      id: 'video',
+      name: 'Video',
+      emoji: '📺',
+      usageLimit: 60,
+      breakTime: 10,
+      domains: Object.freeze([
+        'youtube.com',
+        'netflix.com',
+        'twitch.com',
+        'bilibili.com',
+        'douyin.com',
+        'tiktok.com',
+        'yfsp.tv',
+        'youku.com',
+        'iqiyi.com',
+        'v.qq.com',
+      ]),
+    }),
+    Object.freeze({
+      id: 'shopping',
+      name: 'Shopping',
+      emoji: '🛍️',
+      usageLimit: 20,
+      breakTime: 5,
+      domains: Object.freeze([
+        'amazon.com',
+        'ebay.com',
+        'taobao.com',
+        'tmall.com',
+        'jd.com',
+      ]),
+    }),
   ]);
 
   const DEFAULT_SETTINGS = Object.freeze({
-    catEnabled: true,
-    usageLimit: 30,
-    breakTime: 5,
-    customDomains: DEFAULT_DOMAINS,
+    categories: DEFAULT_CATEGORIES,
   });
 
-  const LEGACY_SNS_DOMAINS = Object.freeze({
-    x: ['x.com', 'twitter.com'],
-    youtube: 'youtube.com',
-    facebook: 'facebook.com',
-    reddit: 'reddit.com',
-    threads: 'threads.net',
-    bluesky: 'bsky.app',
+  // Kept for reading legacy storage during migration from v1
+  const LEGACY_DEFAULTS = Object.freeze({
+    usageLimit: 60,
+    breakTime: 5,
   });
 
   function clampNumber(value, min, max, fallback) {
@@ -116,52 +152,72 @@
     );
   }
 
-  function normalizeSettings(settings) {
-    const safeSettings = settings && typeof settings === 'object' ? settings : {};
-    const customDomains = normalizeDomainList(safeSettings.customDomains);
-    const hasCustomDomainsSetting = Object.prototype.hasOwnProperty.call(
-      safeSettings,
-      'customDomains'
-    );
-    const legacySns = safeSettings.sns && typeof safeSettings.sns === 'object'
-      ? safeSettings.sns
-      : null;
-    const legacyCustomDomains = legacySns
-      ? Object.entries(LEGACY_SNS_DOMAINS)
-        .filter(([key]) => legacySns[key] !== false)
-        .flatMap(([, domain]) => domain)
-      : null;
+  function normalizeCategory(cat) {
+    if (!cat || typeof cat !== 'object') return null;
 
-    return {
-      catEnabled: safeSettings.catEnabled !== false,
-      usageLimit: clampNumber(
-        safeSettings.usageLimit,
-        1,
-        480,
-        DEFAULT_SETTINGS.usageLimit
-      ),
-      breakTime: clampNumber(
-        safeSettings.breakTime,
-        1,
-        60,
-        DEFAULT_SETTINGS.breakTime
-      ),
-      customDomains: hasCustomDomainsSetting
-        ? customDomains
-        : legacyCustomDomains
-          ? legacyCustomDomains
-        : [...DEFAULT_SETTINGS.customDomains],
-    };
+    const id = typeof cat.id === 'string' && cat.id.trim()
+      ? cat.id.trim()
+      : `cat_${Math.random().toString(36).slice(2, 9)}`;
+    const name = (typeof cat.name === 'string' ? cat.name.trim() : '') || 'Category';
+    const emoji = (typeof cat.emoji === 'string' ? [...cat.emoji.trim()].slice(0, 2).join('') : '') || '📌';
+    const usageLimit = clampNumber(cat.usageLimit, 1, 480, 30);
+    const breakTime = clampNumber(cat.breakTime, 1, 60, 5);
+    const domains = normalizeDomainList(cat.domains || []);
+
+    return { id, name, emoji, usageLimit, breakTime, domains };
+  }
+
+  function normalizeCategories(cats) {
+    if (!Array.isArray(cats)) {
+      return DEFAULT_CATEGORIES.map((c) => ({ ...c, domains: [...c.domains] }));
+    }
+    return cats.map(normalizeCategory).filter(Boolean);
+  }
+
+  function normalizeSettings(settings) {
+    const s = settings && typeof settings === 'object' ? settings : {};
+
+    if (Array.isArray(s.categories)) {
+      return { categories: normalizeCategories(s.categories) };
+    }
+
+    // Migrate from v1 flat format
+    if (Array.isArray(s.customDomains)) {
+      return {
+        categories: [normalizeCategory({
+          id: 'migrated',
+          name: 'My Sites',
+          emoji: '📌',
+          usageLimit: s.usageLimit,
+          breakTime: s.breakTime,
+          domains: s.customDomains,
+        })].filter(Boolean),
+      };
+    }
+
+    return { categories: DEFAULT_CATEGORIES.map((c) => ({ ...c, domains: [...c.domains] })) };
+  }
+
+  function getCategoryForHostname(hostname, categories) {
+    if (!Array.isArray(categories)) return null;
+    return categories.find((cat) =>
+      Array.isArray(cat.domains) &&
+      cat.domains.some((d) => hostnameMatchesDomain(hostname, d))
+    ) || null;
   }
 
   return {
     DEFAULT_SETTINGS,
-    DEFAULT_DOMAINS,
+    DEFAULT_CATEGORIES,
+    LEGACY_DEFAULTS,
     clampNumber,
     hostnameMatchesDomain,
     isCustomDomain,
     normalizeDomainEntry,
     normalizeDomainList,
+    normalizeCategory,
+    normalizeCategories,
     normalizeSettings,
+    getCategoryForHostname,
   };
 });


### PR DESCRIPTION
This pull request introduces significant improvements to the extension's multi-category tracking logic, break timer persistence, and localization support. The content script (`content.js`) is refactored to support multiple tracked categories (instead of a single global setting), and now properly persists break timers per site/category. Additionally, the localization files are updated: legacy labels are replaced with new, category-oriented labels, and full Simplified and Traditional Chinese translations are added. There are also minor UI improvements to the popup scrollbar.

  <img width="696" height="1184" alt="image" src="https://github.com/user-attachments/assets/63f6450f-a97d-4082-80d9-98c7ab6ca244" />
  <img width="696" height="744" alt="image" src="https://github.com/user-attachments/assets/b1d16d76-c0dc-4279-9a81-ec7c55f84000" />

**Multi-category tracking and break timer persistence:**

* Refactored `content.js` to support multiple categories, each with their own tracking and break settings, by introducing `currentCategories`, `currentCategory`, and per-category usage/break storage keys. This replaces the previous single-domain/single-setting logic.
* Implemented persistent break timers per category/domain using new storage keys, so breaks are enforced even if the tab is duplicated or the extension is reloaded.

**Localization updates:**

* Removed legacy single-category labels and added new category-based labels in both English and Japanese locale files.
* Added complete Simplified Chinese (`zh_CN`) and Traditional Chinese (`zh_TW`) translation files for all user-facing strings.

**UI improvements:**

* Reduced popup scrollbar width and removed the border for a cleaner look.
**Localization and user-facing text:**

* Updated English and Japanese localization files to remove old global setting labels and add new strings for category management, such as "Add Category," "Remove category," "Emoji," "Name," "Cat appears after," "Break time," "Sites," "min," and quick-add related strings.

These changes lay the groundwork for a more flexible and user-friendly experience, allowing users to manage different site categories with individualized break settings.