### PR TITLE
Persist break state to storage to prevent bypass via tab duplication

### DIFF
--- a/content.js
+++ b/content.js
@@ -13,6 +13,7 @@ const preventScroll = (e) => e.preventDefault();
 
 const hostname = location.hostname;
 const USAGE_STORAGE_KEY = 'catGatekeeperUsage';
+const BREAK_STORAGE_KEY = 'catGatekeeperBreak';
 const USAGE_STALE_AFTER_MS = 30 * 60 * 1000;
 const USAGE_SAVE_INTERVAL_SECONDS = 5;
 
@@ -79,6 +80,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     catIsActive = false;
     stopCountdown();
     resetUsageSeconds(dismissedUsageKey);
+    clearBreakUntil(dismissedUsageKey);
     overlay.style.transition = 'opacity 0.5s';
     overlay.style.opacity = '0';
     setTimeout(() => {
@@ -108,25 +110,8 @@ function getUsageStorageKey(usageKey) {
   return `${USAGE_STORAGE_KEY}:${usageKey}`;
 }
 
-function loadUsageSeconds(usageKey, callback) {
-  const storageKey = getUsageStorageKey(usageKey);
-
-  chrome.storage.local.get({ [storageKey]: null }, (result) => {
-    const entry = result[storageKey];
-    const now = Date.now();
-
-    if (!entry || typeof entry !== 'object') {
-      callback(0);
-      return;
-    }
-
-    if (now - Number(entry.updatedAt || 0) > USAGE_STALE_AFTER_MS) {
-      callback(0);
-      return;
-    }
-
-    callback(Math.max(0, Number.parseInt(entry.seconds, 10) || 0));
-  });
+function getBreakStorageKey(usageKey) {
+  return `${BREAK_STORAGE_KEY}:${usageKey}`;
 }
 
 function saveUsageSeconds(usageKey, seconds) {
@@ -142,6 +127,16 @@ function saveUsageSeconds(usageKey, seconds) {
 
 function resetUsageSeconds(usageKey) {
   saveUsageSeconds(usageKey, 0);
+}
+
+function saveBreakUntil(usageKey, breakUntil) {
+  if (!usageKey) return;
+  chrome.storage.local.set({ [getBreakStorageKey(usageKey)]: breakUntil });
+}
+
+function clearBreakUntil(usageKey) {
+  if (!usageKey) return;
+  chrome.storage.local.remove(getBreakStorageKey(usageKey));
 }
 
 document.addEventListener('visibilitychange', () => {
@@ -162,16 +157,37 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
 
   if (resetUsage) {
     resetUsageSeconds(usageKey);
+    clearBreakUntil(usageKey);
   }
 
-  loadUsageSeconds(usageKey, (initialSeconds) => {
-    if (
-      runId !== trackerRunId ||
-      usageKey !== currentUsageKey ||
-      catIsActive ||
-      !currentSnsEnabled
-    ) {
+  const usageStorageKey = getUsageStorageKey(usageKey);
+  const breakStorageKey = getBreakStorageKey(usageKey);
+
+  chrome.storage.local.get({ [usageStorageKey]: null, [breakStorageKey]: 0 }, (result) => {
+    if (runId !== trackerRunId || usageKey !== currentUsageKey || catIsActive || !currentSnsEnabled) {
       return;
+    }
+
+    // If a break is still active (e.g. tab was duplicated during a break), resume it
+    const breakUntil = Number(result[breakStorageKey]) || 0;
+    const remainingMs = breakUntil - Date.now();
+    if (remainingMs > 0) {
+      catIsActive = true;
+      showCat(Math.ceil(remainingMs / 1000), usageKey, () => {
+        if (currentSnsEnabled && usageKey === currentUsageKey) {
+          startTracking(currentUsageLimit, currentBreakTime);
+        }
+      });
+      return;
+    }
+
+    if (breakUntil > 0) clearBreakUntil(usageKey); // stale entry, clean up
+
+    const entry = result[usageStorageKey];
+    const now = Date.now();
+    let initialSeconds = 0;
+    if (entry && typeof entry === 'object' && now - Number(entry.updatedAt || 0) <= USAGE_STALE_AFTER_MS) {
+      initialSeconds = Math.max(0, Number.parseInt(entry.seconds, 10) || 0);
     }
 
     trackerRunning = true;
@@ -214,7 +230,8 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
         shouldPersistUsage = false;
         localSeconds = 0;
         resetUsageSeconds(usageKey);
-        showCat(breakTime, usageLimit, () => {
+        saveBreakUntil(usageKey, Date.now() + breakTime * 60 * 1000);
+        showCat(breakTime * 60, usageKey, () => {
           if (currentSnsEnabled && usageKey === currentUsageKey) {
             startTracking(currentUsageLimit, currentBreakTime);
           }
@@ -247,7 +264,7 @@ chrome.storage.local.get(null, (settings) => {
   applySettings(settings);
 });
 
-function showCat(breakMinutes, usageLimit, onBreakEnd) {
+function showCat(breakSeconds, usageKey, onBreakEnd) {
   document.getElementById('cat-gatekeeper-overlay')?.remove();
 
   const overlay = document.createElement('div');
@@ -258,7 +275,7 @@ function showCat(breakMinutes, usageLimit, onBreakEnd) {
   // カウントダウン
   const countdown = document.createElement('div');
   countdown.id = 'cat-gatekeeper-countdown';
-  let seconds = breakMinutes * 60;
+  let seconds = breakSeconds;
 
   let countdownCancelled = false;
   stopCountdown = () => { countdownCancelled = true; };
@@ -273,6 +290,7 @@ function showCat(breakMinutes, usageLimit, onBreakEnd) {
       setTimeout(updateCountdown, 1000);
     } else {
       catIsActive = false;
+      clearBreakUntil(usageKey);
       overlay.style.transition = 'opacity 1s';
       overlay.style.opacity = '0';
       setTimeout(() => {


### PR DESCRIPTION
This pull request updates the break tracking logic in `content.js` to reliably persist and clear break state across tab reloads or duplications. The main improvements are the introduction of a dedicated break storage key, more robust handling of break state in storage, and refactoring of related functions for clarity and correctness.

**Break tracking and persistence improvements:**

* Added a new storage key `BREAK_STORAGE_KEY` and corresponding helpers (`getBreakStorageKey`, `saveBreakUntil`, `clearBreakUntil`) to persist break state per usage key.
* Refactored `startTracking` to check for an active break on initialization, resume the break countdown if needed, and clean up stale break entries.
* When a break is triggered, the break end timestamp is now saved to storage, ensuring that breaks persist across tab reloads or duplicates.
* The `showCat` function and break countdown logic were updated to use seconds directly, improving clarity and reducing conversions.
* Break state is now cleared both when the overlay is dismissed and when the break countdown finishes, preventing stale break entries.