### PR TITLE
Add Simplified and Traditional Chinese locales

### DIFF
--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,0 +1,56 @@
+{
+  "appName": {
+    "message": "猫咪守门神"
+  },
+  "appDescription": {
+    "message": "在某些网站上花太多时间了？看看小猫休息一下吧~"
+  },
+  "saveButton": {
+    "message": "保存"
+  },
+  "savedMessage": {
+    "message": "已保存！"
+  },
+  "dismissButton": {
+    "message": "走开，小猫！"
+  },
+  "addCategoryButton": {
+    "message": "+ 添加分类"
+  },
+  "removeCategoryButton": {
+    "message": "删除分类"
+  },
+  "emojiLabel": {
+    "message": "表情"
+  },
+  "categoryNameLabel": {
+    "message": "名称"
+  },
+  "usageLimitShortLabel": {
+    "message": "猫咪出现于"
+  },
+  "breakTimeShortLabel": {
+    "message": "休息时长"
+  },
+  "sitesLabel": {
+    "message": "网站"
+  },
+  "minuteUnit": {
+    "message": "分钟"
+  },
+  "customDomainsHint": {
+    "message": "每行一个，或用逗号分隔。支持输入完整 URL。"
+  },
+  "officialSiteLink": {
+    "message": "官方网站"
+  },
+  "quickAddLabel": {
+    "message": "未追踪 $DOMAIN$",
+    "placeholders": {
+      "domain": { "content": "$1", "example": "example.com" }
+    }
+  },
+  "quickAddButton": {
+    "message": "+ 添加"
+  }
+}

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1,0 +1,56 @@
+{
+  "appName": {
+    "message": "貓咪守門神"
+  },
+  "appDescription": {
+    "message": "在某些網站上花太多時間了？看看小貓休息一下吧~"
+  },
+  "saveButton": {
+    "message": "儲存"
+  },
+  "savedMessage": {
+    "message": "已儲存！"
+  },
+  "dismissButton": {
+    "message": "走開，小貓！"
+  },
+  "addCategoryButton": {
+    "message": "+ 新增分類"
+  },
+  "removeCategoryButton": {
+    "message": "刪除分類"
+  },
+  "emojiLabel": {
+    "message": "表情"
+  },
+  "categoryNameLabel": {
+    "message": "名稱"
+  },
+  "usageLimitShortLabel": {
+    "message": "貓咪出現於"
+  },
+  "breakTimeShortLabel": {
+    "message": "休息時長"
+  },
+  "sitesLabel": {
+    "message": "網站"
+  },
+  "minuteUnit": {
+    "message": "分鐘"
+  },
+  "customDomainsHint": {
+    "message": "每行一個，或用逗號分隔。支援輸入完整 URL。"
+  },
+  "officialSiteLink": {
+    "message": "官方網站"
+  },
+  "quickAddLabel": {
+    "message": "未追蹤 $DOMAIN$",
+    "placeholders": {
+      "domain": { "content": "$1", "example": "example.com" }
+    }
+  },
+  "quickAddButton": {
+    "message": "+ 新增"
+  }
+}


### PR DESCRIPTION
This pull request adds Traditional Chinese (`zh_TW`) and Simplified Chinese (`zh_CN`) translations for the application's user interface. Both new locale files provide translations for all major UI elements, making the app more accessible to Chinese-speaking users.

**Localization:**

* Added a new `_locales/zh_CN/messages.json` file with Simplified Chinese translations for all primary UI strings, including buttons, labels, and hints.
* Added a new `_locales/zh_TW/messages.json` file with Traditional Chinese translations for the same set of UI strings.