### PR TITLE
Support category-based tracking and storage model

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -5,18 +5,6 @@
   "appDescription": {
     "message": "Spend too long on selected sites? A cat hijacks your screen. The cutest forced-break app."
   },
-  "usageLimitLabel": {
-    "message": "Minutes before the cat appears"
-  },
-  "breakTimeLabel": {
-    "message": "Break time (minutes)"
-  },
-  "targetSNSLabel": {
-    "message": "Target sites"
-  },
-  "catEnabledLabel": {
-    "message": "Show the cat"
-  },
   "saveButton": {
     "message": "Save"
   },
@@ -26,10 +14,43 @@
   "dismissButton": {
     "message": "Shoo, kitty!"
   },
+  "addCategoryButton": {
+    "message": "+ Add Category"
+  },
+  "removeCategoryButton": {
+    "message": "Remove category"
+  },
+  "emojiLabel": {
+    "message": "Emoji"
+  },
+  "categoryNameLabel": {
+    "message": "Name"
+  },
+  "usageLimitShortLabel": {
+    "message": "Cat appears after"
+  },
+  "breakTimeShortLabel": {
+    "message": "Break time"
+  },
+  "sitesLabel": {
+    "message": "Sites"
+  },
+  "minuteUnit": {
+    "message": "min"
+  },
   "customDomainsHint": {
     "message": "One per line, or separated by commas. URLs are OK."
   },
   "officialSiteLink": {
     "message": "Official site"
+  },
+  "quickAddLabel": {
+    "message": "$DOMAIN$ is not being tracked",
+    "placeholders": {
+      "domain": { "content": "$1", "example": "example.com" }
+    }
+  },
+  "quickAddButton": {
+    "message": "+ Add"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -5,18 +5,6 @@
   "appDescription": {
     "message": "サイトを使いすぎると猫が現れて画面をジャック。かわいい強制休憩アプリ。"
   },
-  "usageLimitLabel": {
-    "message": "何分使ったら猫を出す？"
-  },
-  "breakTimeLabel": {
-    "message": "猫が居座る時間（分）"
-  },
-  "targetSNSLabel": {
-    "message": "対象サイト"
-  },
-  "catEnabledLabel": {
-    "message": "猫を表示する"
-  },
   "saveButton": {
     "message": "保存"
   },
@@ -26,10 +14,43 @@
   "dismissButton": {
     "message": "退いてもらう"
   },
+  "addCategoryButton": {
+    "message": "+ カテゴリを追加"
+  },
+  "removeCategoryButton": {
+    "message": "カテゴリを削除"
+  },
+  "emojiLabel": {
+    "message": "絵文字"
+  },
+  "categoryNameLabel": {
+    "message": "名前"
+  },
+  "usageLimitShortLabel": {
+    "message": "猫が出るまで"
+  },
+  "breakTimeShortLabel": {
+    "message": "休憩時間"
+  },
+  "sitesLabel": {
+    "message": "サイト"
+  },
+  "minuteUnit": {
+    "message": "分"
+  },
   "customDomainsHint": {
     "message": "1行に1つ、またはカンマ区切り。URLも使えます。"
   },
   "officialSiteLink": {
     "message": "Official site"
+  },
+  "quickAddLabel": {
+    "message": "$DOMAIN$ は追跡されていません",
+    "placeholders": {
+      "domain": { "content": "$1", "example": "example.com" }
+    }
+  },
+  "quickAddButton": {
+    "message": "+ 追加"
   }
 }

--- a/content.js
+++ b/content.js
@@ -16,35 +16,27 @@ const USAGE_STORAGE_KEY = 'catGatekeeperUsage';
 const USAGE_STALE_AFTER_MS = 30 * 60 * 1000;
 const USAGE_SAVE_INTERVAL_SECONDS = 5;
 
-function mergeSettingsWithDefaults(settings) {
-  return shared.normalizeSettings(settings);
-}
-
-function getMatchedDomain(settings) {
-  return shared.normalizeDomainList(settings.customDomains).find((domain) =>
-    shared.hostnameMatchesDomain(hostname, domain)
-  ) || '';
-}
-
-function isSiteEnabled(settings) {
-  return !!getMatchedDomain(settings);
-}
-
 function applySettings(settings, { resetUsage = false } = {}) {
-  const mergedSettings = mergeSettingsWithDefaults(settings);
-  currentUsageLimit = mergedSettings.usageLimit;
-  currentBreakTime = mergedSettings.breakTime;
-  currentCustomDomains = mergedSettings.customDomains;
-  currentUsageKey = getMatchedDomain(mergedSettings);
-  currentSnsEnabled = mergedSettings.catEnabled && !!currentUsageKey;
+  const merged = shared.normalizeSettings(settings);
+  currentCategories = merged.categories;
 
-  if (!currentSnsEnabled) {
+  const newCategory = shared.getCategoryForHostname(hostname, currentCategories);
+
+  if (!newCategory) {
+    currentCategory = null;
+    currentUsageKey = '';
     stopTracker();
     return;
   }
 
+  const matchedDomain = newCategory.domains.find((d) => shared.hostnameMatchesDomain(hostname, d));
+  const newUsageKey = shared.normalizeDomainEntry(matchedDomain || hostname);
+
+  currentCategory = newCategory;
+  currentUsageKey = newUsageKey;
+
   if (!catIsActive) {
-    startTracking(currentUsageLimit, currentBreakTime, { resetUsage });
+    startTracking(newCategory.usageLimit, newCategory.breakTime, { resetUsage });
   }
 }
 
@@ -58,9 +50,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       catIsActive,
       hostname,
       trackerRunning,
-      customDomains: currentCustomDomains,
-      isTracked: currentSnsEnabled,
+      isTracked: !!currentCategory,
       trackedDomain: currentUsageKey,
+      currentCategory,
       hasFocus: document.hasFocus(),
       isHidden: document.hidden,
     });
@@ -86,8 +78,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       document.documentElement.style.overflow = '';
       document.removeEventListener('wheel', preventScroll);
       document.removeEventListener('touchmove', preventScroll);
-      if (currentSnsEnabled && dismissedUsageKey === currentUsageKey) {
-        startTracking(currentUsageLimit, currentBreakTime);
+      if (currentCategory && dismissedUsageKey === currentUsageKey) {
+        startTracking(currentCategory.usageLimit, currentCategory.breakTime);
       }
     }, 500);
   }
@@ -96,10 +88,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 let resetSeconds = () => {};
 let stopTracker = () => {};
 let stopCountdown = () => {};
-let currentUsageLimit = 60;
-let currentBreakTime = 5;
-let currentSnsEnabled = false;
-let currentCustomDomains = [];
+let currentCategories = [];
+let currentCategory = null;
 let currentUsageKey = '';
 let catAssetsPrepared = false;
 let trackerRunId = 0;
@@ -156,8 +146,6 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
   prepareCatAssets();
   stopTracker();
   const runId = ++trackerRunId;
-  currentUsageLimit = usageLimit;
-  currentBreakTime = breakTime;
   const usageKey = currentUsageKey;
 
   if (resetUsage) {
@@ -169,7 +157,7 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
       runId !== trackerRunId ||
       usageKey !== currentUsageKey ||
       catIsActive ||
-      !currentSnsEnabled
+      !currentCategory
     ) {
       return;
     }
@@ -191,7 +179,7 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
     };
 
     const tracker = setInterval(() => {
-      if (usageKey !== currentUsageKey || catIsActive || !currentSnsEnabled) {
+      if (usageKey !== currentUsageKey || catIsActive || !currentCategory) {
         clearInterval(tracker);
         trackerRunning = false;
         return;
@@ -215,8 +203,8 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
         localSeconds = 0;
         resetUsageSeconds(usageKey);
         showCat(breakTime, usageLimit, () => {
-          if (currentSnsEnabled && usageKey === currentUsageKey) {
-            startTracking(currentUsageLimit, currentBreakTime);
+          if (currentCategory && usageKey === currentUsageKey) {
+            startTracking(currentCategory.usageLimit, currentCategory.breakTime);
           }
         });
       }
@@ -243,9 +231,10 @@ function prepareCatAssets() {
   catAssetsPrepared = true;
 }
 
-chrome.storage.local.get(null, (settings) => {
-  applySettings(settings);
-});
+chrome.storage.local.get(
+  { categories: null, customDomains: null, usageLimit: shared.LEGACY_DEFAULTS.usageLimit, breakTime: shared.LEGACY_DEFAULTS.breakTime },
+  (settings) => applySettings(settings)
+);
 
 function showCat(breakMinutes, usageLimit, onBreakEnd) {
   document.getElementById('cat-gatekeeper-overlay')?.remove();

--- a/shared.js
+++ b/shared.js
@@ -7,30 +7,66 @@
 
   root.CatGatekeeperShared = shared;
 })(typeof globalThis !== 'undefined' ? globalThis : this, () => {
-  const DEFAULT_DOMAINS = Object.freeze([
-    'x.com',
-    'twitter.com',
-    'youtube.com',
-    'facebook.com',
-    'reddit.com',
-    'threads.net',
-    'bsky.app',
+  const DEFAULT_CATEGORIES = Object.freeze([
+    Object.freeze({
+      id: 'social',
+      name: 'Social',
+      emoji: '💬',
+      usageLimit: 30,
+      breakTime: 5,
+      domains: Object.freeze([
+        'x.com',
+        'facebook.com',
+        'threads.net',
+        'instagram.com',
+        'bsky.app',
+        'xiaohongshu.com',
+        'reddit.com',
+      ]),
+    }),
+    Object.freeze({
+      id: 'video',
+      name: 'Video',
+      emoji: '📺',
+      usageLimit: 60,
+      breakTime: 10,
+      domains: Object.freeze([
+        'youtube.com',
+        'netflix.com',
+        'twitch.com',
+        'bilibili.com',
+        'douyin.com',
+        'tiktok.com',
+        'yfsp.tv',
+        'youku.com',
+        'iqiyi.com',
+        'v.qq.com',
+      ]),
+    }),
+    Object.freeze({
+      id: 'shopping',
+      name: 'Shopping',
+      emoji: '🛍️',
+      usageLimit: 20,
+      breakTime: 5,
+      domains: Object.freeze([
+        'amazon.com',
+        'ebay.com',
+        'taobao.com',
+        'tmall.com',
+        'jd.com',
+      ]),
+    }),
   ]);
 
   const DEFAULT_SETTINGS = Object.freeze({
-    catEnabled: true,
-    usageLimit: 30,
-    breakTime: 5,
-    customDomains: DEFAULT_DOMAINS,
+    categories: DEFAULT_CATEGORIES,
   });
 
-  const LEGACY_SNS_DOMAINS = Object.freeze({
-    x: ['x.com', 'twitter.com'],
-    youtube: 'youtube.com',
-    facebook: 'facebook.com',
-    reddit: 'reddit.com',
-    threads: 'threads.net',
-    bluesky: 'bsky.app',
+  // Kept for reading legacy storage during migration from v1
+  const LEGACY_DEFAULTS = Object.freeze({
+    usageLimit: 60,
+    breakTime: 5,
   });
 
   function clampNumber(value, min, max, fallback) {
@@ -116,52 +152,72 @@
     );
   }
 
-  function normalizeSettings(settings) {
-    const safeSettings = settings && typeof settings === 'object' ? settings : {};
-    const customDomains = normalizeDomainList(safeSettings.customDomains);
-    const hasCustomDomainsSetting = Object.prototype.hasOwnProperty.call(
-      safeSettings,
-      'customDomains'
-    );
-    const legacySns = safeSettings.sns && typeof safeSettings.sns === 'object'
-      ? safeSettings.sns
-      : null;
-    const legacyCustomDomains = legacySns
-      ? Object.entries(LEGACY_SNS_DOMAINS)
-        .filter(([key]) => legacySns[key] !== false)
-        .flatMap(([, domain]) => domain)
-      : null;
+  function normalizeCategory(cat) {
+    if (!cat || typeof cat !== 'object') return null;
 
-    return {
-      catEnabled: safeSettings.catEnabled !== false,
-      usageLimit: clampNumber(
-        safeSettings.usageLimit,
-        1,
-        480,
-        DEFAULT_SETTINGS.usageLimit
-      ),
-      breakTime: clampNumber(
-        safeSettings.breakTime,
-        1,
-        60,
-        DEFAULT_SETTINGS.breakTime
-      ),
-      customDomains: hasCustomDomainsSetting
-        ? customDomains
-        : legacyCustomDomains
-          ? legacyCustomDomains
-        : [...DEFAULT_SETTINGS.customDomains],
-    };
+    const id = typeof cat.id === 'string' && cat.id.trim()
+      ? cat.id.trim()
+      : `cat_${Math.random().toString(36).slice(2, 9)}`;
+    const name = (typeof cat.name === 'string' ? cat.name.trim() : '') || 'Category';
+    const emoji = (typeof cat.emoji === 'string' ? [...cat.emoji.trim()].slice(0, 2).join('') : '') || '📌';
+    const usageLimit = clampNumber(cat.usageLimit, 1, 480, 30);
+    const breakTime = clampNumber(cat.breakTime, 1, 60, 5);
+    const domains = normalizeDomainList(cat.domains || []);
+
+    return { id, name, emoji, usageLimit, breakTime, domains };
+  }
+
+  function normalizeCategories(cats) {
+    if (!Array.isArray(cats)) {
+      return DEFAULT_CATEGORIES.map((c) => ({ ...c, domains: [...c.domains] }));
+    }
+    return cats.map(normalizeCategory).filter(Boolean);
+  }
+
+  function normalizeSettings(settings) {
+    const s = settings && typeof settings === 'object' ? settings : {};
+
+    if (Array.isArray(s.categories)) {
+      return { categories: normalizeCategories(s.categories) };
+    }
+
+    // Migrate from v1 flat format
+    if (Array.isArray(s.customDomains)) {
+      return {
+        categories: [normalizeCategory({
+          id: 'migrated',
+          name: 'My Sites',
+          emoji: '📌',
+          usageLimit: s.usageLimit,
+          breakTime: s.breakTime,
+          domains: s.customDomains,
+        })].filter(Boolean),
+      };
+    }
+
+    return { categories: DEFAULT_CATEGORIES.map((c) => ({ ...c, domains: [...c.domains] })) };
+  }
+
+  function getCategoryForHostname(hostname, categories) {
+    if (!Array.isArray(categories)) return null;
+    return categories.find((cat) =>
+      Array.isArray(cat.domains) &&
+      cat.domains.some((d) => hostnameMatchesDomain(hostname, d))
+    ) || null;
   }
 
   return {
     DEFAULT_SETTINGS,
-    DEFAULT_DOMAINS,
+    DEFAULT_CATEGORIES,
+    LEGACY_DEFAULTS,
     clampNumber,
     hostnameMatchesDomain,
     isCustomDomain,
     normalizeDomainEntry,
     normalizeDomainList,
+    normalizeCategory,
+    normalizeCategories,
     normalizeSettings,
+    getCategoryForHostname,
   };
 });


### PR DESCRIPTION
This pull request introduces a major refactor to support multiple categories of tracked sites, each with its own settings (such as emoji, name, usage limit, and break time). It replaces the previous single-list approach with a more flexible, category-based system, and updates both the English and Japanese locale files to match the new UI and logic. Additionally, it improves data migration from older versions and cleans up the core logic for determining which category applies to the current site.

The most important changes are:

### Core functionality refactor

* Replaced the previous single-list site tracking system with a new category-based system, where each category has its own `usageLimit`, `breakTime`, `emoji`, `name`, and list of domains. The logic for finding the matching category for the current site is now handled by `getCategoryForHostname`, and all usage tracking is based on the matched category. (`shared.js`, `content.js`)

* Added robust normalization and migration logic to convert old settings (flat list of domains and global limits) into the new categories format, ensuring backward compatibility for existing users. (`shared.js`)

### Localization and UI labels

* Updated the English and Japanese locale files to remove old labels and add new ones for category management, such as "Add Category", "Remove Category", "Emoji", "Name", and other labels reflecting the new category-based UI. (`_locales/en/messages.json`, `_locales/ja/messages.json`)

### Default data and migration

* Defined a set of default categories (Social, Video, Shopping) with appropriate default domains, usage limits, and emojis. This provides a better out-of-the-box experience for new users. (`shared.js`)

* The code now initializes settings with the new category structure, whether from storage or defaults, and ensures that all logic operates on the category model. (`content.js`, `shared.js`)

Overall, these changes lay the groundwork for a more extensible and user-friendly experience, allowing users to manage time limits for different types of sites independently.