### PR TITLE
Fix: Add immediate limit check to prevent 1s delay

### DIFF
--- a/content.js
+++ b/content.js
@@ -174,6 +174,18 @@ function startTracking(usageLimit, breakTime, { resetUsage = false } = {}) {
       return;
     }
 
+    // すでに制限時間を超えている場合は即座に猫を出す
+    if (initialSeconds >= usageLimit * 60) {
+      catIsActive = true;
+      resetUsageSeconds(usageKey);
+      showCat(breakTime, usageLimit, () => {
+        if (currentSnsEnabled && usageKey === currentUsageKey) {
+          startTracking(currentUsageLimit, currentBreakTime);
+        }
+      });
+      return;
+    }
+
     trackerRunning = true;
     let localSeconds = resetUsage ? 0 : initialSeconds;
     let secondsSinceSave = 0;


### PR DESCRIPTION
This pull request refines the usage tracking logic in `content.js` to ensure more predictable behavior when a user hits their limit or opens a new tab.

### Tracking and state improvements

*   **Immediate limit check**: Added a check in `startTracking` to trigger the cat overlay instantly if the stored usage is already over the limit upon initialization. This prevents the previous 1-second delay where users could interact with a site before the tracker interval kicked in.
*   **Race condition fix**: Refactored the `stopTracker` and `resetSeconds` logic to prevent stale usage data from being written back to storage during the reset process.
*   **Improved local state management**: `localSeconds` is now reset locally as soon as the cat is triggered, ensuring that redundant storage writes do not overwrite the zeroed usage key.
