### PR TITLE
Feat: Add Shadow DOM support for Brave Shields compatibility

### DIFF
--- a/content.css
+++ b/content.css
@@ -9,6 +9,7 @@
   display: flex !important;
   align-items: center !important;
   justify-content: center !important;
+  pointer-events: auto !important;
 }
 
 #cat-gatekeeper-overlay video {

--- a/content.js
+++ b/content.js
@@ -51,6 +51,27 @@ function applySettings(settings, { resetUsage = false } = {}) {
 let catIsActive = false;
 let trackerRunning = false;
 
+// Shadow DOM helper
+function getShadowRoot() {
+  const hostId = 'cat-gk-host';
+  let host = document.getElementById(hostId);
+  if (!host) {
+    host = document.createElement('div');
+    host.id = hostId;
+    host.style.position = 'fixed';
+    host.style.top = '0';
+    host.style.left = '0';
+    host.style.width = '0';
+    host.style.height = '0';
+    host.style.zIndex = '2147483647';
+    document.documentElement.appendChild(host);
+  }
+  if (!host.shadowRoot) {
+    host.attachShadow({ mode: 'open' });
+  }
+  return host.shadowRoot;
+}
+
 // ポップアップからのメッセージを受け取る
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message.type === 'GET_CAT_STATUS') {
@@ -73,7 +94,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   }
 
   if (message.type === 'DISMISS_CAT') {
-    const overlay = document.getElementById('cat-gatekeeper-overlay');
+    const shadow = getShadowRoot();
+    const overlay = shadow.getElementById('cat-gatekeeper-overlay');
     if (!overlay) return;
     const dismissedUsageKey = currentUsageKey;
     catIsActive = false;
@@ -83,6 +105,11 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     overlay.style.opacity = '0';
     setTimeout(() => {
       overlay.remove();
+      const host = document.getElementById('cat-gk-host');
+      if (host) {
+        host.style.width = '0';
+        host.style.height = '0';
+      }
       document.documentElement.style.overflow = '';
       document.removeEventListener('wheel', preventScroll);
       document.removeEventListener('touchmove', preventScroll);
@@ -92,6 +119,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     }, 500);
   }
 });
+
 
 let resetSeconds = () => {};
 let stopTracker = () => {};
@@ -248,7 +276,18 @@ chrome.storage.local.get(null, (settings) => {
 });
 
 function showCat(breakMinutes, usageLimit, onBreakEnd) {
-  document.getElementById('cat-gatekeeper-overlay')?.remove();
+  const shadow = getShadowRoot();
+  const host = document.getElementById('cat-gk-host');
+  host.style.width = '100vw';
+  host.style.height = '100vh';
+
+  // Inject CSS into Shadow DOM
+  if (!shadow.querySelector('link')) {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = chrome.runtime.getURL('content.css');
+    shadow.appendChild(link);
+  }
 
   const overlay = document.createElement('div');
   overlay.id = 'cat-gatekeeper-overlay';
@@ -277,6 +316,8 @@ function showCat(breakMinutes, usageLimit, onBreakEnd) {
       overlay.style.opacity = '0';
       setTimeout(() => {
         overlay.remove();
+        host.style.width = '0';
+        host.style.height = '0';
         document.documentElement.style.overflow = '';
         document.removeEventListener('wheel', preventScroll);
         document.removeEventListener('touchmove', preventScroll);
@@ -306,14 +347,14 @@ function showCat(breakMinutes, usageLimit, onBreakEnd) {
   overlay.appendChild(countdown);
   overlay.appendChild(video);
   overlay.appendChild(videoSleep);
-  document.body.appendChild(overlay);
+  shadow.appendChild(overlay);
   document.documentElement.style.overflow = 'hidden';
   document.addEventListener('wheel', preventScroll, { passive: false });
   document.addEventListener('touchmove', preventScroll, { passive: false });
 
   // ページ上の動画を一時停止（猫の動画は除く）
   document.querySelectorAll('video').forEach(v => {
-    if (v !== video && v !== videoSleep) v.pause();
+    if (v !== video && v !== videoSleep && !shadow.contains(v)) v.pause();
   });
 
   // neko1が終わったらneko2に切り替え
@@ -324,3 +365,4 @@ function showCat(breakMinutes, usageLimit, onBreakEnd) {
     videoSleep.play();
   });
 }
+

--- a/manifest.json
+++ b/manifest.json
@@ -34,17 +34,17 @@
         "http://*/*",
         "https://*/*"
       ],
-      "js": ["shared.js", "content.js"],
-      "css": ["content.css"]
+      "js": ["shared.js", "content.js"]
     }
   ],
   "web_accessible_resources": [
     {
-      "resources": ["assets/*"],
+      "resources": ["assets/*", "content.css"],
       "matches": [
         "http://*/*",
         "https://*/*"
       ]
     }
   ]
+
 }


### PR DESCRIPTION
This pull request addresses a common issue where aggressive content filters (such as Brave Shields) block or hide the cat overlay on social media sites.

### Brave Shields compatibility improvements

*   **Shadow DOM implementation**: Moved the cat overlay into a `shadowRoot` attached to a host element on the document root. This isolates the extension's UI from the host page's DOM and CSS, preventing ad-blockers from incorrectly identifying and hiding the overlay elements.
*   **Manifest updates**: Updated `manifest.json` to include `content.css` in `web_accessible_resources`, allowing it to be loaded via a link tag within the Shadow Root.
*   **Style isolation**: Removed global CSS injection for the overlay to prevent style leakage into the host page, ensuring that `#cat-gatekeeper-overlay` styles are only active within the extension's isolated container.
